### PR TITLE
Pass __filename into createApp for "error" app

### DIFF
--- a/app/templates/apps/error/_index.coffee
+++ b/app/templates/apps/error/_index.coffee
@@ -1,6 +1,6 @@
 derby = require 'derby'
 
-errorApp = module.exports = derby.createApp "error", __filename
+errorApp = module.exports = derby.createApp 'error', __filename
 <% if (jade) { %>
 errorApp.serverUse module, 'derby-jade'<% } %><% if (stylus) { %>
 errorApp.serverUse module, 'derby-stylus'<% } %>

--- a/app/templates/apps/error/_index.coffee
+++ b/app/templates/apps/error/_index.coffee
@@ -1,6 +1,6 @@
 derby = require 'derby'
 
-errorApp = module.exports = derby.createApp()
+errorApp = module.exports = derby.createApp "error", __filename
 <% if (jade) { %>
 errorApp.serverUse module, 'derby-jade'<% } %><% if (stylus) { %>
 errorApp.serverUse module, 'derby-stylus'<% } %>

--- a/app/templates/apps/error/_index.js
+++ b/app/templates/apps/error/_index.js
@@ -1,6 +1,6 @@
 var derby = require('derby');
 
-var errorApp = module.exports = derby.createApp();
+var errorApp = module.exports = derby.createApp("error", __filename);
 <% if (jade) { %>
 errorApp.serverUse(module,'derby-jade');<% } %><% if (stylus) { %>
 errorApp.serverUse(module, 'derby-stylus');<% } %>

--- a/app/templates/apps/error/_index.js
+++ b/app/templates/apps/error/_index.js
@@ -1,6 +1,6 @@
 var derby = require('derby');
 
-var errorApp = module.exports = derby.createApp("error", __filename);
+var errorApp = module.exports = derby.createApp('error', __filename);
 <% if (jade) { %>
 errorApp.serverUse(module,'derby-jade');<% } %><% if (stylus) { %>
 errorApp.serverUse(module, 'derby-stylus');<% } %>


### PR DESCRIPTION
I came across the following error

```
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at App._init (/home/ubuntu/datavis-tech/node_modules/derby/lib/App.server.js:37:29)
    at new App (/home/ubuntu/datavis-tech/node_modules/derby/lib/App.js:32:8)
    at Racer.Derby.createApp (/home/ubuntu/datavis-tech/node_modules/derby/lib/Derby.js:23:10)
    at Object.<anonymous> (/home/ubuntu/datavis-tech/apps/error/index.js:3:39)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
```

Tracking this down led me to the conclusion that due to a [recent change in Nodejs](https://github.com/nodejs/node/pull/1153/files), omitting the filepath from the call to `createApp` was the source of this error.

The proposed changes make the error go away. I have manually tested the JS version only.
